### PR TITLE
Pi zero 2 W supports DietPi v64

### DIFF
--- a/DietPi_64/os.json
+++ b/DietPi_64/os.json
@@ -11,6 +11,7 @@
     "download_size": 122999112,
     "supported_hex_revisions": "2082,20d3,20e0,3111,3112",
     "supported_models": [
+        "Pi Zero 2 W",
         "Pi Compute Module 3",
         "Pi Compute Module 4",
         "Pi 3",

--- a/os_list_v3.json
+++ b/os_list_v3.json
@@ -244,6 +244,7 @@
             "release_date": "2021-12-12",
             "supported_hex_revisions": "2082,20d3,20e0,3111,3112",
             "supported_models": [
+                "Pi Zero 2 W",
                 "Pi Compute Module 3",
                 "Pi Compute Module 4",
                 "Pi 3",


### PR DESCRIPTION
Dietpi for armv8 is officialy supported by pi zero 2. 

Already tested the installation of dietpi on pi zero 2 via PINN. It works correctly. 